### PR TITLE
feat: batch publish messages

### DIFF
--- a/services/avito-poller/avito_poller.py
+++ b/services/avito-poller/avito_poller.py
@@ -5,7 +5,7 @@ import requests
 import json
 import time
 from datetime import datetime, timedelta
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Any
 sys.path.append('/opt/smart-seller/services')
 
 from base_service import BaseSmartSellerService
@@ -18,6 +18,7 @@ class EnhancedAvitoPollerService(BaseSmartSellerService):
         self.polling_interval = int(os.getenv('AVITO_POLLING_INTERVAL', 30))
         self.api_timeout = int(os.getenv('AVITO_API_TIMEOUT', 30))
         self.api_base_url = 'https://api.avito.ru'
+        self.batch_size = int(os.getenv('RABBITMQ_BATCH_SIZE', 50))
         
         if not self.user_id:
             self.logger.error("❌ AVITO_USER_ID должен быть указан!")
@@ -352,12 +353,11 @@ class EnhancedAvitoPollerService(BaseSmartSellerService):
                 elif extracted_raw is None:
                     extracted_data = {}
             
-            # Отправляем каждое новое сообщение с полным контекстом
+            batch: List[Dict[str, Any]] = []
             for message in new_messages:
                 content = message.get('content', {})
                 message_text = content.get('text', '') if isinstance(content, dict) else str(content)
-                
-                # Создаем полную структуру для AI
+
                 ai_message = {
                     'message_id': message.get('id'),
                     'chat_id': chat_id,
@@ -366,33 +366,38 @@ class EnhancedAvitoPollerService(BaseSmartSellerService):
                     'timestamp': datetime.fromtimestamp(message.get('created', 0)).isoformat() if message.get('created') else datetime.now().isoformat(),
                     'direction': 'incoming' if message.get('direction') == 'in' else 'outgoing',
                     'source': 'avito',
-                    
-                    # ПОЛНЫЙ КОНТЕКСТ ДЛЯ AI
                     'conversation_context': {
-                        'full_chronological_history': full_history,  # Вся история диалога
-                        'current_ai_context': ai_context,           # Текущий контекст AI
-                        'extracted_data': extracted_data,           # Уже извлеченные данные
+                        'full_chronological_history': full_history,
+                        'current_ai_context': ai_context,
+                        'extracted_data': extracted_data,
                         'total_messages': len(full_history),
                         'conversation_stage': 'active',
                         'requires_processing': True
                     }
                 }
-                
-                # Отправляем в RabbitMQ для обработки AI
-                success = self.publish_message(
+
+                batch.append(ai_message)
+                self.logger.info(f"📥 Добавлено сообщение в пакет: {message_text[:30]}...")
+
+                if len(batch) >= self.batch_size:
+                    if not self.publish_messages_batch(
+                        exchange=self.exchange,
+                        routing_key='ai.message.new_with_context',
+                        messages=batch
+                    ):
+                        self.logger.error("❌ Ошибка отправки сообщения в RabbitMQ")
+                        return False
+                    batch = []
+
+            if batch:
+                if not self.publish_messages_batch(
                     exchange=self.exchange,
                     routing_key='ai.message.new_with_context',
-                    message=ai_message
-                )
-                
-                if success:
-                    self.logger.info(f"✅ Отправлено сообщение с контекстом: {message_text[:30]}...")
-                else:
-                    self.logger.error(f"❌ Ошибка отправки сообщения в RabbitMQ")
+                    messages=batch
+                ):
+                    self.logger.error("❌ Ошибка отправки сообщения в RabbitMQ")
                     return False
-                
-                time.sleep(0.1)  # Небольшая пауза между сообщениями
-            
+
             return True
             
         except Exception as e:

--- a/services/base_service.py
+++ b/services/base_service.py
@@ -8,7 +8,7 @@ import os
 import sys
 import signal
 from dotenv import load_dotenv
-from typing import Callable, Dict, Any, Optional
+from typing import Callable, Dict, Any, Optional, List
 from datetime import datetime
 
 class BaseSmartSellerService:
@@ -166,6 +166,41 @@ class BaseSmartSellerService:
         except Exception as e:
             self.logger.error(f"❌ Ошибка отправки сообщения: {e}")
             return False
+
+    def publish_messages_batch(self, exchange: str, routing_key: str, messages: List[Dict[Any, Any]]):
+        try:
+            if not messages:
+                return True
+
+            self.rabbitmq_channel.tx_select()
+
+            enriched_message = {
+                'timestamp': datetime.utcnow().isoformat(),
+                'service': self.service_name,
+                'data': messages
+            }
+
+            self.rabbitmq_channel.basic_publish(
+                exchange=exchange,
+                routing_key=routing_key,
+                body=json.dumps(enriched_message, ensure_ascii=False),
+                properties=pika.BasicProperties(
+                    delivery_mode=2,
+                    content_type='application/json'
+                )
+            )
+
+            self.rabbitmq_channel.tx_commit()
+            self.logger.info(f"📤 Отправлен пакет сообщений: {len(messages)}")
+            return True
+
+        except Exception as e:
+            try:
+                self.rabbitmq_channel.tx_rollback()
+            except Exception:
+                pass
+            self.logger.error(f"❌ Ошибка отправки пакетных сообщений: {e}")
+            return False
     
     def consume_messages(self, queue: str, callback: Callable):
         try:
@@ -173,16 +208,30 @@ class BaseSmartSellerService:
                 try:
                     message = json.loads(body.decode('utf-8'))
                     self.logger.info(f"📥 Получено сообщение из {queue}")
-                    
-                    success = callback(message)
-                    
-                    if success:
-                        ch.basic_ack(delivery_tag=method.delivery_tag)
-                        self.logger.info("✅ Сообщение обработано")
+
+                    data = message.get('data') if isinstance(message, dict) else None
+                    if isinstance(data, list):
+                        all_success = True
+                        for item in data:
+                            single_message = {**message, 'data': item}
+                            if not callback(single_message):
+                                all_success = False
+                                break
+                        if all_success:
+                            ch.basic_ack(delivery_tag=method.delivery_tag)
+                            self.logger.info("✅ Пакет сообщений обработан")
+                        else:
+                            ch.basic_nack(delivery_tag=method.delivery_tag, requeue=False)
+                            self.logger.error("❌ Ошибка обработки сообщения из пакета")
                     else:
-                        ch.basic_nack(delivery_tag=method.delivery_tag, requeue=False)
-                        self.logger.error("❌ Ошибка обработки сообщения")
-                        
+                        success = callback(message)
+                        if success:
+                            ch.basic_ack(delivery_tag=method.delivery_tag)
+                            self.logger.info("✅ Сообщение обработано")
+                        else:
+                            ch.basic_nack(delivery_tag=method.delivery_tag, requeue=False)
+                            self.logger.error("❌ Ошибка обработки сообщения")
+
                 except Exception as e:
                     self.logger.error(f"❌ Ошибка в обработчике сообщений: {e}")
                     ch.basic_nack(delivery_tag=method.delivery_tag, requeue=False)


### PR DESCRIPTION
## Summary
- send Avito poller messages in batches and remove delay
- add transactional batch publishing helper
- allow queue consumer to handle batch payloads

## Testing
- `python -m py_compile services/base_service.py services/avito-poller/avito_poller.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68950b5e3acc8326a78f3e0f76674b3c